### PR TITLE
Ensure that web server directory listing HTML contains correct file links

### DIFF
--- a/source/rtl/ultibo/core/http.pas
+++ b/source/rtl/ultibo/core/http.pas
@@ -8361,7 +8361,7 @@ begin
      end
     else
      begin
-      WorkBuffer:=WorkBuffer + '<li><a href="' + SearchRec.Name + '"> ' + SearchRec.Name + '</a></li>' + HTTP_LINE_END;
+      WorkBuffer:=WorkBuffer + '<li><a href="' + AddTrailingChar(ARequest.URL,HTTP_PATH_SEPARATOR) + SearchRec.Name + '"> ' + SearchRec.Name + '</a></li>' + HTTP_LINE_END;
      end;
    until FindNext(SearchRec) <> 0;
   end;


### PR DESCRIPTION
Consider the following fragment of Ultibo application code;

      HTTPFolder:=THTTPFolder.Create;
      HTTPFolder.Name:='/datalogs';
      HTTPFolder.Folder:='C:\datalogs';

      HTTPListener.RegisterDocument('',HTTPFolder);

This registers a folder c:\datalogs as /datalogs so that you can browse to http://<server>/datalogs and you'll get a traditional file listing.

The file listing you get will list all files and folders, and each one is clickable, allowing navigation around the folder tree, and downloading. However, the href links to all of the files will reference the root directory "/", not /datalogs/.

This change adjusts the generated href's to include the base URL.  I have tested it on a couple of different browsers and it seems OK.