### PR TITLE
Update VGShapes to support optional shared eGL contexts between layers.

### DIFF
--- a/source/packages/ultibounits/src/vgshapes.pas
+++ b/source/packages/ultibounits/src/vgshapes.pas
@@ -87,6 +87,8 @@ procedure VGShapesFinish;
 function VGShapesGetLayer:LongInt;
 procedure VGShapesSetLayer(layer:LongInt);
 
+function VGShapesLayerHasSharedEGLContext(LayerId:Longint = VGSHAPES_NOLAYER):Boolean;
+
 {Font}
 function VGShapesLoadFont(Points,PointIndices:PInteger;Instructions:PByte;InstructionIndices,InstructionCounts,adv:PInteger;cmap:PSmallInt;ng:Integer):TVGShapesFontInfo;
 procedure VGShapesUnloadFont(glyphs:PVGPath;n:Integer);
@@ -330,6 +332,20 @@ begin
       end; 
     end;
   end;
+end;
+
+{==============================================================================}
+function VGShapesLayerHasSharedEGLContext(LayerId:Longint = VGSHAPES_NOLAYER):Boolean;
+begin
+ Result:=false;
+
+ {use current layer if none specified}
+ if (LayerId=VGSHAPES_NOLAYER) then
+  LayerId:=Current;
+
+ {check layer initialized}
+ if Layers[Current].Initialized then
+   Result:=Layers[Current].SharedContextWithLayer<>VGSHAPES_NOLAYER;
 end;
 
 {==============================================================================}


### PR DESCRIPTION
While looking through the OpenVG specification recently, I noticed that there is an option when creating an eGL surface to specify a shared context. In VGShapes we currently put a nil for this parameter when calling `eglCreateContext()`, which means that all handles to graphic objects (paths, paints, bitmaps etc) can only be used in the context within which they were created. So for example to draw the same bitmap on two different layers, you must currently create two separate GPU objects which is wasteful on GPU memory as the image data has to be loaded into the GPU twice.

An area where this is particularly wasteful within VGShapes itself is when using fonts on multiple layers, as the font paths are independently created on a per layer basis (albeit only on an as needed basis for layers after the first one created).

This pull request implements an option to request that a layer is to share its context with another already created layer. This is done by calling `VGShapesInit()` with an additional parameter `ShareContextWithLayer`:

`function VGShapesInit(var w,h:Integer;alphaflags:DISPMANX_FLAGS_ALPHA_T = DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS; layer:LongInt = VGSHAPES_NOLAYER;ShareContextWithLayer:integer = VGSHAPES_NOLAYER):Boolean;`

This new parameter is defaulted so that existing behaviour is retained for any application that is recompiled against the new code.

Specifying a valid, already initialised, layer in this function call causes the eGL context for that layer to be used as the share context in the call to `eglCreateContext()` for the layer you are creating. You can initialise several layers with the same share layer, so for example create layer 0, then create layers 1 and 2 both with a share context of layer 0. This allows all three layers to use any GPU object that was created when any of these three layers was active. You can also create layer 0, then layer 1 sharing 0's context, and layer 2 sharing 1's context. These two scenarios have the same effect.

There are a few places that have been changed to cope with this;
- App fonts and internal fonts are now reference counted to allow the sharing to work efficiently.
- Fonts are only released from GPU memory when their reference counter hits zero
- the internal font functions check for shared context settings and take different actions in the shared scenario.

I also fixed a bug that, in the non-shared scenario, stops the three internal fonts from being released on secondary layers when `VGShapesFinish()` is called. This is present in the current RTL and is caused by the fact that the app font list entries for the internal fonts are not patched up when the `VGShapes<typface>()` functions create the fonts for secondary layers, as is done when the first layer is created.

When using a shared context the internal fonts are still only 'created' on request but now the creation is only copying of a font structure pointer and incrementing a reference count, rather than creation of new paths under the layer's previously independent eGL context.

A new convenience function has been added:
`function VGShapesLoadSharedAppFont(const appfontname:String):PVGShapesFontInfo;`

If layer B shares context with layer A, then once an initial call has been made to `VGShapesLoadAppFont()` on layer A, then `VGShapesLoadSharedAppFont()` can be called with just the name on layer B to allow the font to be used. This locates the font on layer A and adjusts its reference count.

It is possible to still call `VGShapesLoadAppFont()` on multiple layers whose contexts are being shared; the code will ignore all parameters except the `fontname` and will do exactly the same as `VGShapesLoadSharedAppFont()` does.

If no shared context layer is specified, then everything should work exactly as it does before, with everything being independent and tied to the context of the layer it was created under. I have deliberately avoided enabling shared contexts as a default in case someone is specifically dependent on the existing behaviour, so I have not taken the opportunity to simplify things in the way we really could.

Mixtures of shared and non-shared contexts between layers are possible and should work as you'd expect.

Note: This pull request contains some logging under the directive `VGSHAPES_LOG`. I have only used 'writeln' for this logging as I wasn't sure whether we wanted to avoid dependencies on the RTL. Therefore to capture the log output you will need to look at the console window after closing all layers, or redirect the output somewhere else with a TextIOWriteCharHandler. This logging is really only present to help with evaluation of the pull request, and can ultimately be removed completely when ready. Let me know if you would like the pull request to be updated to remove the logging once you've had a look.

Testing performed:
- I have run this new version of VGShapes against my multi-layered digital cluster application without making any changes to the application, and verified that without any shared contexts the behaviour is exactly the same.
- I have tested various combinations of sharing contexts on applications with up to 3 layers, loaded bitmaps created on one layer into another, and loaded shared fonts. I have not tested other GPU primitives but there is no reason to suspect they won't work the same way, as it's the GPU/firmware that implements them, not VGShapes.
- Logging used to ensure that everything is cleaned up correctly and reference counts are monitored
- added multiple app fonts and remove them more times than added to check it doesn't crash.
- added app fonts to one layer, added to another layer with the new `VGShapesLoadSharedAppFont()` function that only requires a name, and confirmed that the font can be drawn on both layers.

One thing you can't do as it will result in an inconsistent internal state, is to unload an app font with `VGShapesUnloadAppFont()` using one of the internal font names (e.g. 'sans'), and then reference that system font with one of the internal font functions e.g. `VGShapesSansTypeface()` as the font will not be reloaded. I believe that problem exists in the current implementation and it's a pretty stupid thing to do anyway.
